### PR TITLE
ファイルパスの記述方法をOS依存しない形へ修正

### DIFF
--- a/SerialController/GuiAssets.py
+++ b/SerialController/GuiAssets.py
@@ -99,13 +99,14 @@ class CaptureArea(tk.Canvas):
         # self._logger.addHandler(self.stick_handler)
         # self._logger.propagate = False
         if isTakeLog:
-            self.LS = logging.FileHandler(filename=f"log\\{nowtime}_LStick.log", encoding='utf-8')
+            filename_base = os.path.join("log", f"{nowtime}")
+            self.LS = logging.FileHandler(filename=f"{filename_base}_LStick.log", encoding='utf-8')
             self.LS.setLevel(logging.DEBUG)
             self.LSTICK_logger = logging.getLogger("L_STICK")
             self.LSTICK_logger.setLevel(logging.DEBUG)
             self.LSTICK_logger.addHandler(self.LS)
 
-            self.RS = logging.FileHandler(filename=f"log\\{nowtime}_RStick.log", encoding='utf-8')
+            self.RS = logging.FileHandler(filename=f"{filename_base}_RStick.log", encoding='utf-8')
             self.RS.setLevel(logging.DEBUG)
             self.RSTICK_logger = logging.getLogger("R_STICK")
             self.RSTICK_logger.setLevel(logging.DEBUG)

--- a/SerialController/LineNotify.py
+++ b/SerialController/LineNotify.py
@@ -32,12 +32,13 @@ class Line_Notify:
         """
         utf-8 のファイルを BOM ありかどうかを自動判定して読み込む
         """
-        is_with_bom = self.is_utf8_file_with_bom(os.path.dirname(__file__) + '\\line_token.ini')
+        line_token_path = os.path.join(os.path.dirname(__file__), 'line_token.ini')
+        is_with_bom = self.is_utf8_file_with_bom(line_token_path)
 
         encoding = 'utf-8-sig' if is_with_bom else 'utf-8'
 
         self._logger.debug("Load token file")
-        self.token_file.read(os.path.dirname(__file__) + '\\line_token.ini', encoding)
+        self.token_file.read(line_token_path, encoding)
 
     def is_utf8_file_with_bom(self, filename):
         """
@@ -128,7 +129,7 @@ class Line_Notify:
         except AttributeError as e:
             self._logger.error(e)
             pass
-        except KeyError  as e:
+        except KeyError as e:
             self._logger.error(e)
             pass
 


### PR DESCRIPTION
# 修正内容
- line_token.iniの読み込み
- [L/R]_Stickのログ出力

におけるパス記述方法を、OSに依存しない形へ修正

## 修正理由
Raspberry Pi 4 (Raspberry Pi OS 64bit)上で動作させることを試みた際、line_token.iniを読み込むことができなかったため

## 解決方法
os.path.join()を使用することで、動作環境ごとに適切な区切り文字['\\' | '/']が挿入されるように修正

-----

# Fixes
- Load line_token.ini
- Output [L/ R]_Stick log

Corrected the path description method in the above so that it does not depend on the OS.

## Reason for correction
When I tried to run it on Raspberry Pi 4 (Raspberry Pi OS 64bit), line_token.ini could not be load.

## Solutions
Fixed to insert the appropriate delimiter ['\\' |'/'] for each operating environment by using os.path.join ()