### PR TITLE
Fix/path join

### DIFF
--- a/SerialController/Camera.py
+++ b/SerialController/Camera.py
@@ -125,11 +125,12 @@ class Camera:
         else:
             image = self.image_bgr
 
-        if not os.path.exists(self.capture_dir):
-            os.makedirs(self.capture_dir)
-            self._logger.debug("Created Capture folder")
-
         save_path = _get_save_filespec(filename)
+
+        if not os.path.exists(os.path.dirname(save_path)) or not os.path.isdir(os.path.dirname(save_path)):
+            # 保存先ディレクトリが存在しないか、同名のファイルが存在する場合（existsはファイルとフォルダを区別しない）
+            os.makedirs(os.path.dirname(save_path))
+            self._logger.debug("Created Capture folder")
 
         try:
             imwrite(save_path, image)

--- a/SerialController/Camera.py
+++ b/SerialController/Camera.py
@@ -29,12 +29,31 @@ def imwrite(filename, img, params=None):
         return False
 
 
+CAPTURE_DIR = "./Captures/"
+def _get_save_filespec(filename: str) -> str:
+    """
+    画像ファイルの保存パスを取得する。
+
+    入力が絶対パスの場合は、`CAPTURE_DIR`につなげずに返す。
+
+    Args:
+        filename (str): 保存名／保存パス
+
+    Returns:
+        str: _description_
+    """
+    if os.path.isabs(filename):
+        return filename
+    else:
+        return os.path.join(CAPTURE_DIR, filename)
+
+
 class Camera:
     def __init__(self, fps=45):
         self.camera = None
         self.capture_size = (1280, 720)
         # self.capture_size = (1920, 1080)
-        self.capture_dir = "Captures"
+        self.capture_dir = CAPTURE_DIR
         self.fps = int(fps)
 
         self._logger = getLogger(__name__)
@@ -110,7 +129,7 @@ class Camera:
             os.makedirs(self.capture_dir)
             self._logger.debug("Created Capture folder")
 
-        save_path = os.path.join(self.capture_dir, filename)
+        save_path = _get_save_filespec(filename)
 
         try:
             imwrite(save_path, image)

--- a/SerialController/Camera.py
+++ b/SerialController/Camera.py
@@ -53,7 +53,7 @@ class Camera:
         self.camera = None
         self.capture_size = (1280, 720)
         # self.capture_size = (1920, 1080)
-        self.capture_dir = CAPTURE_DIR
+        self.capture_dir = "Captures"
         self.fps = int(fps)
 
         self._logger = getLogger(__name__)

--- a/SerialController/Commands/PythonCommandBase.py
+++ b/SerialController/Commands/PythonCommandBase.py
@@ -9,6 +9,7 @@ from time import sleep
 import random
 import time
 from logging import getLogger, DEBUG, NullHandler
+from os import path
 import tkinter as tk
 import tkinter.ttk as ttk
 
@@ -297,6 +298,22 @@ class PokeConDialogue(object):
 
 
 TEMPLATE_PATH = "./Template/"
+def _get_template_filespec(template_path: str) -> str:
+    """
+    テンプレート画像ファイルのパスを取得する。
+
+    入力が絶対パスの場合は、`TEMPLATE_PATH`につなげずに返す。
+
+    Args:
+        template_path (str): 画像パス
+
+    Returns:
+        str: _description_
+    """
+    if path.isabs(template_path):
+        return template_path
+    else:
+        return path.join(TEMPLATE_PATH, template_path)
 
 
 class ImageProcPythonCommand(PythonCommand):
@@ -329,7 +346,7 @@ class ImageProcPythonCommand(PythonCommand):
         if len(crop) == 4:
             src = src[crop[1]: crop[3], crop[0]: crop[2]]
         
-        template = cv2.imread(TEMPLATE_PATH + template_path, cv2.IMREAD_GRAYSCALE if use_gray else cv2.IMREAD_COLOR)
+        template = cv2.imread(_get_template_filespec(template_path), cv2.IMREAD_GRAYSCALE if use_gray else cv2.IMREAD_COLOR)
         w, h = template.shape[1], template.shape[0]
 
         method = cv2.TM_CCOEFF_NORMED
@@ -375,7 +392,7 @@ class ImageProcPythonCommand(PythonCommand):
         max_val_list = []
         judge_threshold_list = []
         for template_path in template_path_list:
-            template = cv2.imread(TEMPLATE_PATH + template_path, cv2.IMREAD_GRAYSCALE if use_gray else cv2.IMREAD_COLOR)
+            template = cv2.imread(_get_template_filespec(template_path), cv2.IMREAD_GRAYSCALE if use_gray else cv2.IMREAD_COLOR)
             w, h = template.shape[1], template.shape[0]
 
             method = cv2.TM_CCOEFF_NORMED
@@ -418,7 +435,7 @@ class ImageProcPythonCommand(PythonCommand):
 
             self.gsrc.upload(src)
 
-            template = cv2.imread(TEMPLATE_PATH + template_path, cv2.IMREAD_GRAYSCALE if use_gray else cv2.IMREAD_COLOR)
+            template = cv2.imread(_get_template_filespec(template_path), cv2.IMREAD_GRAYSCALE if use_gray else cv2.IMREAD_COLOR)
             self.gtmpl.upload(template)
 
             method = cv2.TM_CCOEFF_NORMED

--- a/SerialController/Commands/PythonCommands/TestPath.py
+++ b/SerialController/Commands/PythonCommands/TestPath.py
@@ -20,7 +20,7 @@ def _test_save_capture(command: ImageProcPythonCommand):
     test_cases = [
         # ファイル名のみ
         ("_test", "./Captures/_test.png"),
-        # 相対パス ⇒ saveCapture未対応
+        # 相対パス
         ("_test/_test", "./Captures/_test/_test.png"),
         # 絶対パス
         (path.join(path.dirname(__file__), "_test"),

--- a/SerialController/Commands/PythonCommands/TestPath.py
+++ b/SerialController/Commands/PythonCommands/TestPath.py
@@ -1,0 +1,56 @@
+from os import path
+from Commands.PythonCommandBase import ImageProcPythonCommand
+
+
+class TestCase:
+    def __init__(self, input: str, expected: str, ignore: bool = False) -> None:
+        self.__input = input
+        self.__expected = expected
+        self.__ignore = ignore
+
+    @property
+    def input(self):
+        return self.__input
+
+    @property
+    def expected(self):
+        return self.__expected
+
+    @property
+    def ignore(self):
+        return self.__ignore
+
+
+class TestPath(ImageProcPythonCommand):
+
+    NAME = "パス指定のテスト"
+
+    def __init__(self, cam):
+        super().__init__(cam)
+
+    def do(self):
+
+        test_cases = [
+            # ファイル名のみ
+            TestCase("_test", "./Captures/_test.png"),
+            # 相対パス ⇒ saveCapture未対応
+            TestCase("_test/_test", "./Captures/_test/_test.png", True),
+            # 絶対パス
+            TestCase(path.join(path.dirname(__file__), "_test"),
+                     path.join(path.dirname(__file__), "_test.png"))
+        ]
+
+        print("saveCapture")
+        for test_case in test_cases:
+            if test_case.ignore:
+                continue
+            self.camera.saveCapture(test_case.input)
+            if not path.exists(test_case.expected):
+                print(
+                    f"failure\ninput:{test_case.input}\noutput:{test_case.expected}")
+                return
+
+        print("isContainTemplate")
+        for test_case in test_cases:
+            self.isContainTemplate(test_case.input)
+            # ログ目視

--- a/SerialController/Commands/PythonCommands/TestPath.py
+++ b/SerialController/Commands/PythonCommands/TestPath.py
@@ -1,24 +1,54 @@
 from os import path
+import os
 from Commands.PythonCommandBase import ImageProcPythonCommand
 
 
-class TestCase:
-    def __init__(self, input: str, expected: str, ignore: bool = False) -> None:
-        self.__input = input
-        self.__expected = expected
-        self.__ignore = ignore
+def _test_save_capture(command: ImageProcPythonCommand):
+    test_cases = [
+        # ファイル名のみ
+        ("_test", "./Captures/_test.png"),
+        # 相対パス ⇒ saveCapture未対応
+        ("_test/_test", "./Captures/_test/_test.png"),
+        # 絶対パス
+        (path.join(path.dirname(__file__), "_test"),
+         path.join(path.dirname(__file__), "_test.png")),
+    ]
 
-    @property
-    def input(self):
-        return self.__input
+    for test_case in test_cases:
 
-    @property
-    def expected(self):
-        return self.__expected
+        if path.exists(test_case[1]):
+            os.remove(test_case[1])
 
-    @property
-    def ignore(self):
-        return self.__ignore
+        command.camera.saveCapture(test_case[0])
+        if not path.exists(test_case[1]):
+            print(
+                f"----------\n[FAILURE]\ninput:{test_case[0]}\nexpected:{test_case[1]}\n----------\n")
+        else:
+            print(
+                f"----------\n[SUCCESSED]\ninput:{test_case[0]}\nexpected:{test_case[1]}\n----------\n")
+            os.remove(test_case[1])
+
+
+def _test_is_contain_template(command: ImageProcPythonCommand):
+    test_cases = [
+        # ファイル名のみ
+        ("_test.png", "./Template/_test.png"),
+        # 相対パス
+        ("_test/_test.png", "./Template/_test/_test.png"),
+        # 絶対パス
+        (path.join(path.dirname(__file__), "__test.png"),
+         path.join(path.dirname(__file__), "__test.png")),
+    ]
+
+    for test_case in test_cases:
+        try:
+            command.isContainTemplate(test_case[0])
+            print(
+                f"----------\n[SUCCESSED]\ninput:{test_case[0]}\nexpected:{test_case[1]}\n----------\n")
+        except:
+            print(
+                f"----------\n[FAILURE]\ninput:{test_case[0]}\nexpected:{test_case[1]}\n----------\n")
+        # ログ目視
 
 
 class TestPath(ImageProcPythonCommand):
@@ -29,28 +59,8 @@ class TestPath(ImageProcPythonCommand):
         super().__init__(cam)
 
     def do(self):
+        print("\n====================\nsaveCapture\n====================\n")
+        _test_save_capture(self)
 
-        test_cases = [
-            # ファイル名のみ
-            TestCase("_test", "./Captures/_test.png"),
-            # 相対パス ⇒ saveCapture未対応
-            TestCase("_test/_test", "./Captures/_test/_test.png", True),
-            # 絶対パス
-            TestCase(path.join(path.dirname(__file__), "_test"),
-                     path.join(path.dirname(__file__), "_test.png"))
-        ]
-
-        print("saveCapture")
-        for test_case in test_cases:
-            if test_case.ignore:
-                continue
-            self.camera.saveCapture(test_case.input)
-            if not path.exists(test_case.expected):
-                print(
-                    f"failure\ninput:{test_case.input}\noutput:{test_case.expected}")
-                return
-
-        print("isContainTemplate")
-        for test_case in test_cases:
-            self.isContainTemplate(test_case.input)
-            # ログ目視
+        print("\n====================\nisContainTemplate\n====================\n")
+        _test_is_contain_template(self)

--- a/SerialController/Commands/PythonCommands/TestPath.py
+++ b/SerialController/Commands/PythonCommands/TestPath.py
@@ -1,9 +1,22 @@
 from os import path
 import os
+import shutil
 from Commands.PythonCommandBase import ImageProcPythonCommand
 
 
 def _test_save_capture(command: ImageProcPythonCommand):
+    """
+    saveCaptureの挙動を確認する
+
+    | 入力           | 期待される挙動                                   |
+    | -------------- | ------------------------------------------------ |
+    | ファイル名のみ | `./Captures`以下に保存                           |
+    | 相対パス       | `./Captures`以下に新規ディレクトリを作成して保存 |
+    | 絶対パス       | 指定先に保存                                     |
+
+    Args:
+        command (ImageProcPythonCommand): _description_
+    """
     test_cases = [
         # ファイル名のみ
         ("_test", "./Captures/_test.png"),
@@ -22,32 +35,55 @@ def _test_save_capture(command: ImageProcPythonCommand):
         command.camera.saveCapture(test_case[0])
         if not path.exists(test_case[1]):
             print(
-                f"----------\n[FAILURE]\ninput:{test_case[0]}\nexpected:{test_case[1]}\n----------\n")
+                f"----------\n[FAILURE]\ninput: {test_case[0]}\nexpected: {test_case[1]}\n----------\n")
         else:
             print(
-                f"----------\n[SUCCESSED]\ninput:{test_case[0]}\nexpected:{test_case[1]}\n----------\n")
+                f"----------\n[SUCCESSED]\ninput: {test_case[0]}\nexpected: {test_case[1]}\n----------\n")
             os.remove(test_case[1])
 
 
 def _test_is_contain_template(command: ImageProcPythonCommand):
+    """
+    isContainTemplateの挙動を確認する
+
+    | 入力           | 期待される挙動                         |
+    | -------------- | -------------------------------------- |
+    | ファイル名のみ | `./Template`以下から取得               |
+    | 相対パス       | `./Template`以下のディレクトリから取得 |
+    | 絶対パス       | 指定先から取得                         |
+
+    Args:
+        command (ImageProcPythonCommand): _description_
+    """
     test_cases = [
         # ファイル名のみ
         ("_test.png", "./Template/_test.png"),
         # 相対パス
         ("_test/_test.png", "./Template/_test/_test.png"),
         # 絶対パス
-        (path.join(path.dirname(__file__), "__test.png"),
-         path.join(path.dirname(__file__), "__test.png")),
+        (path.join(path.dirname(__file__), "_test.png"),
+         path.join(path.dirname(__file__), "_test.png")),
     ]
+
+    # ダミーのテンプレートを配置
+    for test_case in test_cases:
+        command.camera.saveCapture("_")
+        try:
+            os.makedirs(path.dirname(test_case[1]))
+        except:
+            pass
+        shutil.move("./Captures/_.png", test_case[1])
 
     for test_case in test_cases:
         try:
             command.isContainTemplate(test_case[0])
             print(
-                f"----------\n[SUCCESSED]\ninput:{test_case[0]}\nexpected:{test_case[1]}\n----------\n")
-        except:
+                f"----------\n[SUCCESSED]\ninput: {test_case[0]}\nexpected: {test_case[1]}\n----------\n")
+        except Exception as e:
             print(
-                f"----------\n[FAILURE]\ninput:{test_case[0]}\nexpected:{test_case[1]}\n----------\n")
+                f"----------\n[FAILURE]\n{str(e)}\ninput: {test_case[0]}\nexpected: {test_case[1]}\n----------\n")
+        finally:
+            os.remove(test_case[1])
         # ログ目視
 
 


### PR DESCRIPTION
`saveCapture`と`isContainTemplate`に絶対パスを渡した場合、デフォルトのパスをつなげないようにしました。
従来のパス指定には影響せず、絶対パスを指定した場合の挙動を変更します。

## `saveCapture`

あまり考えられない用途ですが、相対パス指定でディレクトリが存在しない場合、新規ディレクトリを作成して保存するようにしました。

| 入力           | 従来の挙動                                         | 期待される挙動                                   |
| -------------- | -------------------------------------------------- | ------------------------------------------------ |
| ファイル名のみ | `./Captures`以下に保存                             | （変更なし）                                     |
| 相対パス       | ディレクトリが存在する場合は成功、しない場合は失敗 | `./Captures`以下に新規ディレクトリを作成して保存 |
| 絶対パス       | 失敗                                               | 指定先に保存                                     |

## `isContainTemplate`

| 入力           | 従来の挙動                             | 期待される挙動 |
| -------------- | -------------------------------------- | -------------- |
| ファイル名のみ | `./Template`以下から取得               | （変更なし）   |
| 相対パス       | `./Template`以下のディレクトリから取得 | （変更なし）   |
| 絶対パス       | 失敗                                   | 指定先から取得 |
